### PR TITLE
feat(trips): implement RabbitMQ consumer for reservation events

### DIFF
--- a/backend/trips-api/internal/messaging/consumer.go
+++ b/backend/trips-api/internal/messaging/consumer.go
@@ -1,0 +1,330 @@
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// Inbound exchange/queue configuration (from bookings-api)
+	consumerExchange = "reservations.events" // Topic exchange
+	consumerQueue    = "trips.reservations"  // Durable queue
+	bindingKey       = "reservation.*"       // Matches reservation.created, reservation.cancelled
+
+	// Consumer settings
+	prefetchCount = 10                   // Process 10 messages concurrently
+	consumerTag   = "trips-api-consumer" // Consumer identifier
+)
+
+// TripServiceInterface define los métodos necesarios del trip service para el consumer
+// Esto evita import cycles entre messaging y service
+type TripServiceInterface interface {
+	ProcessReservationCreated(ctx context.Context, event ReservationCreatedEvent) error
+	ProcessReservationCancelled(ctx context.Context, event ReservationCancelledEvent) error
+}
+
+// IdempotencyServiceInterface define los métodos necesarios del idempotency service
+type IdempotencyServiceInterface interface {
+	CheckAndMarkEvent(ctx context.Context, eventID, eventType string) (shouldProcess bool, err error)
+}
+
+// ReservationConsumer define la interfaz para consumir eventos de reservas
+type ReservationConsumer interface {
+	Start(ctx context.Context) error
+	Close() error
+}
+
+type reservationConsumer struct {
+	conn               *amqp.Connection
+	channel            *amqp.Channel
+	tripService        TripServiceInterface
+	idempotencyService IdempotencyServiceInterface
+	publisher          Publisher
+}
+
+// NewReservationConsumer crea una nueva instancia del consumer de reservas
+func NewReservationConsumer(
+	rabbitURL string,
+	tripService TripServiceInterface,
+	idempotencyService IdempotencyServiceInterface,
+	publisher Publisher,
+) (ReservationConsumer, error) {
+	// Conectar a RabbitMQ
+	conn, err := amqp.Dial(rabbitURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to RabbitMQ: %w", err)
+	}
+
+	// Crear canal
+	ch, err := conn.Channel()
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to open channel: %w", err)
+	}
+
+	// Declarar exchange (idempotente - no falla si ya existe)
+	err = ch.ExchangeDeclare(
+		consumerExchange, // name
+		exchangeType,     // type: topic
+		true,             // durable: sobrevive a reinicio del broker
+		false,            // auto-deleted
+		false,            // internal
+		false,            // no-wait
+		nil,              // arguments
+	)
+	if err != nil {
+		ch.Close()
+		conn.Close()
+		return nil, fmt.Errorf("failed to declare exchange: %w", err)
+	}
+
+	// Declarar queue durable
+	queue, err := ch.QueueDeclare(
+		consumerQueue, // name
+		true,          // durable: sobrevive a reinicio
+		false,         // delete when unused
+		false,         // exclusive
+		false,         // no-wait
+		nil,           // arguments
+	)
+	if err != nil {
+		ch.Close()
+		conn.Close()
+		return nil, fmt.Errorf("failed to declare queue: %w", err)
+	}
+
+	// Bind queue to exchange con routing key pattern
+	err = ch.QueueBind(
+		queue.Name,       // queue name
+		bindingKey,       // routing key pattern
+		consumerExchange, // exchange
+		false,            // no-wait
+		nil,              // arguments
+	)
+	if err != nil {
+		ch.Close()
+		conn.Close()
+		return nil, fmt.Errorf("failed to bind queue: %w", err)
+	}
+
+	// Configurar QoS (prefetch count)
+	err = ch.Qos(
+		prefetchCount, // prefetch count: procesar N mensajes concurrentemente
+		0,             // prefetch size
+		false,         // global
+	)
+	if err != nil {
+		ch.Close()
+		conn.Close()
+		return nil, fmt.Errorf("failed to set QoS: %w", err)
+	}
+
+	log.Info().
+		Str("exchange", consumerExchange).
+		Str("queue", consumerQueue).
+		Str("binding_key", bindingKey).
+		Int("prefetch", prefetchCount).
+		Msg("RabbitMQ consumer configured successfully")
+
+	return &reservationConsumer{
+		conn:               conn,
+		channel:            ch,
+		tripService:        tripService,
+		idempotencyService: idempotencyService,
+		publisher:          publisher,
+	}, nil
+}
+
+// Start comienza a consumir mensajes (bloquea hasta que el contexto sea cancelado)
+func (c *reservationConsumer) Start(ctx context.Context) error {
+	// Iniciar consumo de mensajes
+	deliveries, err := c.channel.Consume(
+		consumerQueue, // queue
+		consumerTag,   // consumer tag
+		false,         // auto-ack: FALSE - manual ACK
+		false,         // exclusive
+		false,         // no-local
+		false,         // no-wait
+		nil,           // args
+	)
+	if err != nil {
+		return fmt.Errorf("failed to start consuming: %w", err)
+	}
+
+	log.Info().
+		Str("queue", consumerQueue).
+		Str("consumer_tag", consumerTag).
+		Msg("Started consuming reservation events")
+
+	// Loop de procesamiento de mensajes
+	for {
+		select {
+		case <-ctx.Done():
+			// Contexto cancelado - graceful shutdown
+			log.Info().Msg("Consumer context cancelled, stopping...")
+			return nil
+
+		case delivery, ok := <-deliveries:
+			if !ok {
+				// Canal cerrado - conexión perdida
+				log.Warn().Msg("Deliveries channel closed, consumer stopping")
+				return fmt.Errorf("deliveries channel closed")
+			}
+
+			// Procesar mensaje
+			err := c.handleDelivery(ctx, delivery)
+			if err != nil {
+				// Error de sistema - NACK con requeue
+				log.Error().
+					Err(err).
+					Str("message_id", delivery.MessageId).
+					Msg("Failed to process message, will retry")
+				delivery.Nack(false, true) // requeue=true
+			} else {
+				// Éxito o fallo manejado - ACK
+				delivery.Ack(false)
+			}
+		}
+	}
+}
+
+// handleDelivery procesa un solo mensaje
+func (c *reservationConsumer) handleDelivery(ctx context.Context, delivery amqp.Delivery) error {
+	// Log del mensaje recibido
+	log.Debug().
+		Str("routing_key", delivery.RoutingKey).
+		Str("content_type", delivery.ContentType).
+		Int("body_size", len(delivery.Body)).
+		Msg("Received message")
+
+	// Parsear evento base para obtener event_id y event_type
+	var baseEvent struct {
+		EventID   string `json:"event_id"`
+		EventType string `json:"event_type"`
+	}
+	if err := json.Unmarshal(delivery.Body, &baseEvent); err != nil {
+		log.Error().Err(err).Msg("Failed to unmarshal base event")
+		return nil // ACK - mensaje inválido no se puede procesar
+	}
+
+	// CRÍTICO: Verificar idempotencia PRIMERO
+	shouldProcess, err := c.idempotencyService.CheckAndMarkEvent(ctx, baseEvent.EventID, baseEvent.EventType)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("event_id", baseEvent.EventID).
+			Str("event_type", baseEvent.EventType).
+			Msg("Idempotency check failed")
+		return err // NACK - retry
+	}
+
+	if !shouldProcess {
+		log.Info().
+			Str("event_id", baseEvent.EventID).
+			Str("event_type", baseEvent.EventType).
+			Msg("Event already processed, skipping")
+		return nil // ACK - skip processing
+	}
+
+	// Rutear al handler apropiado según el tipo de evento
+	switch baseEvent.EventType {
+	case "reservation.created":
+		return c.handleReservationCreated(ctx, delivery.Body)
+
+	case "reservation.cancelled":
+		return c.handleReservationCancelled(ctx, delivery.Body)
+
+	default:
+		log.Warn().
+			Str("event_type", baseEvent.EventType).
+			Msg("Unknown event type, ignoring")
+		return nil // ACK - tipo desconocido
+	}
+}
+
+// handleReservationCreated procesa eventos de reserva creada
+func (c *reservationConsumer) handleReservationCreated(ctx context.Context, body []byte) error {
+	var event ReservationCreatedEvent
+	if err := json.Unmarshal(body, &event); err != nil {
+		log.Error().Err(err).Msg("Failed to unmarshal reservation.created event")
+		return nil // ACK - JSON inválido
+	}
+
+	log.Info().
+		Str("event_id", event.EventID).
+		Str("trip_id", event.TripID).
+		Str("reservation_id", event.ReservationID).
+		Int("seats_reserved", event.SeatsReserved).
+		Msg("Processing reservation.created event")
+
+	// Delegar al servicio de negocio
+	err := c.tripService.ProcessReservationCreated(ctx, event)
+	if err != nil {
+		// Error de sistema - NACK
+		log.Error().
+			Err(err).
+			Str("event_id", event.EventID).
+			Msg("Failed to process reservation.created")
+		return err
+	}
+
+	log.Info().
+		Str("event_id", event.EventID).
+		Str("trip_id", event.TripID).
+		Msg("Successfully processed reservation.created event")
+	return nil
+}
+
+// handleReservationCancelled procesa eventos de reserva cancelada
+func (c *reservationConsumer) handleReservationCancelled(ctx context.Context, body []byte) error {
+	var event ReservationCancelledEvent
+	if err := json.Unmarshal(body, &event); err != nil {
+		log.Error().Err(err).Msg("Failed to unmarshal reservation.cancelled event")
+		return nil // ACK - JSON inválido
+	}
+
+	log.Info().
+		Str("event_id", event.EventID).
+		Str("trip_id", event.TripID).
+		Str("reservation_id", event.ReservationID).
+		Int("seats_released", event.SeatsReleased).
+		Msg("Processing reservation.cancelled event")
+
+	// Delegar al servicio de negocio
+	err := c.tripService.ProcessReservationCancelled(ctx, event)
+	if err != nil {
+		// Error de sistema - NACK
+		log.Error().
+			Err(err).
+			Str("event_id", event.EventID).
+			Msg("Failed to process reservation.cancelled")
+		return err
+	}
+
+	log.Info().
+		Str("event_id", event.EventID).
+		Str("trip_id", event.TripID).
+		Msg("Successfully processed reservation.cancelled event")
+	return nil
+}
+
+// Close cierra el canal y la conexión de RabbitMQ
+func (c *reservationConsumer) Close() error {
+	if c.channel != nil {
+		if err := c.channel.Close(); err != nil {
+			log.Error().Err(err).Msg("Error closing consumer channel")
+		}
+	}
+	if c.conn != nil {
+		if err := c.conn.Close(); err != nil {
+			log.Error().Err(err).Msg("Error closing consumer connection")
+			return err
+		}
+	}
+	log.Info().Msg("RabbitMQ consumer closed successfully")
+	return nil
+}

--- a/backend/trips-api/internal/messaging/events.go
+++ b/backend/trips-api/internal/messaging/events.go
@@ -24,3 +24,44 @@ type TripCancelledEvent struct {
 	CancelledBy        int64  `json:"cancelled_by"`         // ID del usuario que canceló
 	CancellationReason string `json:"cancellation_reason"`  // Razón de la cancelación
 }
+
+// ============================================================================
+// INCOMING EVENTS (Consumed from bookings-api)
+// ============================================================================
+
+// ReservationCreatedEvent representa un evento de reserva creada (incoming from bookings-api)
+type ReservationCreatedEvent struct {
+	EventID       string    `json:"event_id"`        // UUID v4 - CRÍTICO para idempotencia
+	EventType     string    `json:"event_type"`      // "reservation.created"
+	TripID        string    `json:"trip_id"`         // MongoDB ObjectID como string
+	SeatsReserved int       `json:"seats_reserved"`  // Número de asientos a reservar
+	ReservationID string    `json:"reservation_id"`  // UUID de bookings-api
+	Timestamp     time.Time `json:"timestamp"`       // Timestamp del evento
+}
+
+// ReservationCancelledEvent representa un evento de reserva cancelada (incoming from bookings-api)
+type ReservationCancelledEvent struct {
+	EventID       string    `json:"event_id"`        // UUID v4 - CRÍTICO para idempotencia
+	EventType     string    `json:"event_type"`      // "reservation.cancelled"
+	TripID        string    `json:"trip_id"`         // MongoDB ObjectID como string
+	SeatsReleased int       `json:"seats_released"`  // Número de asientos a liberar
+	ReservationID string    `json:"reservation_id"`  // UUID de bookings-api
+	Timestamp     time.Time `json:"timestamp"`       // Timestamp del evento
+}
+
+// ============================================================================
+// OUTGOING COMPENSATING EVENTS
+// ============================================================================
+
+// ReservationFailedEvent representa un evento de compensación cuando falla una reserva
+type ReservationFailedEvent struct {
+	EventID        string    `json:"event_id"`        // Nuevo UUID v4
+	EventType      string    `json:"event_type"`      // "reservation.failed"
+	ReservationID  string    `json:"reservation_id"`  // UUID de la reserva que falló
+	TripID         string    `json:"trip_id"`         // MongoDB ObjectID como string
+	Reason         string    `json:"reason"`          // "No seats available" | "Version conflict"
+	AvailableSeats int       `json:"available_seats"` // Cantidad actual de asientos disponibles
+	SourceService  string    `json:"source_service"`  // "trips-api"
+	CorrelationID  string    `json:"correlation_id"`  // Para tracing de requests
+	Timestamp      time.Time `json:"timestamp"`       // Timestamp del evento
+}


### PR DESCRIPTION
Add consumer for reservation.created and reservation.cancelled events with idempotency checks, optimistic locking, and compensating events. Consumer uses mark-first strategy for idempotency and manual ACK/NACK.

- Add ReservationConsumer with queue 'trips.reservations' bound to 'reservations.events' exchange
- Implement ProcessReservationCreated/Cancelled in TripService with optimistic locking
- Add PublishReservationFailure for compensating events when seats unavailable
- Add ReservationCreatedEvent, ReservationCancelledEvent, ReservationFailedEvent structures
- Wire consumer in main.go with goroutine and graceful shutdown via context cancellation
- Use local interfaces in consumer to avoid import cycles
- CRITICAL: Idempotency check FIRST before processing (CheckAndMarkEvent)
- Handle ErrOptimisticLockFailed with compensation event publishing
- Manual ACK on success or handled failure, NACK with requeue on system errors